### PR TITLE
Circumvents the deprecation of copy-paste oauth

### DIFF
--- a/sdk/python/kfp/client/auth.py
+++ b/sdk/python/kfp/client/auth.py
@@ -190,12 +190,14 @@ def get_refresh_token_from_client_id(client_id, client_secret):
 
 
 def get_auth_code(client_id):
-    auth_url = "https://accounts.google.com/o/oauth2/v2/auth?client_id=%s&response_type=code&scope=openid%%20email&access_type=offline&redirect_uri=urn:ietf:wg:oauth:2.0:oob" % client_id
+    auth_url = "https://accounts.google.com/o/oauth2/v2/auth?client_id=%s&response_type=code&scope=openid%%20email&access_type=offline&redirect_uri=http://localhost:1" % client_id
     print(auth_url)
     open_new_tab(auth_url)
     return input(
-        "If there's no browser window prompt, please direct to the URL above, "
-        "then copy and paste the authorization code here: ")
+        "If there's no browser window prompt, please direct to the URL above,\n"
+        "At the end the browser will fail to connect to http://localhost:1/?code=SOMECODE&scope=... \n"
+        "Copy the value of SOMECODE from the address and paste it below")
+        
 
 
 def get_refresh_token_from_code(auth_code, client_id, client_secret):
@@ -203,7 +205,7 @@ def get_refresh_token_from_code(auth_code, client_id, client_secret):
         "code": auth_code,
         "client_id": client_id,
         "client_secret": client_secret,
-        "redirect_uri": "urn:ietf:wg:oauth:2.0:oob",
+        "redirect_uri": "http://localhost:1",
         "grant_type": "authorization_code"
     }
     res = requests.post(OAUTH_TOKEN_URI, data=payload)


### PR DESCRIPTION
This is a quick-and-dirty hack to circumvent the deprecation of copy-paste oauth authentification for google cloud.
https://stackoverflow.com/questions/71318804/google-oauth-2-0-failing-with-error-400-invalid-request-for-some-client-id-but/71327990#71327990

**Description of your changes:**


**Checklist:**
- [ ] The title for your pull request (PR) should follow our title convention. [Learn more about the pull request title convention used in this repository](https://github.com/kubeflow/pipelines/blob/master/CONTRIBUTING.md#pull-request-title-convention). 
<!--
   PR titles examples:
    * `fix(frontend): fixes empty page. Fixes #1234`
       Use `fix` to indicate that this PR fixes a bug.
    * `feat(backend): configurable service account. Fixes #1234, fixes #1235`
       Use `feat` to indicate that this PR adds a new feature. 
    * `chore: set up changelog generation tools`
       Use `chore` to indicate that this PR makes some changes that users don't need to know.
    * `test: fix CI failure. Part of #1234`
        Use `part of` to indicate that a PR is working on an issue, but shouldn't close the issue when merged.
-->
